### PR TITLE
opal-demo's dsuser password updated

### DIFF
--- a/inst/shinyApp/connection.R
+++ b/inst/shinyApp/connection.R
@@ -25,7 +25,7 @@ observeEvent(input$add, {
                                               }
                                               });'
                                            )))),
-                                           passwordInput(paste0("password", tabIndex()), "Password", value = "password")
+                                           passwordInput(paste0("password", tabIndex()), "Password", value = "P@ssw0rd")
                                          ),
                                          materialSwitch(inputId = paste0("pat_switch", tabIndex()), label = "Use Personal Access Token", status = "primary")
                                   )


### PR DESCRIPTION
Last Opal (4.3) implements strong user password policy. Please rebuild the docker image so that the datashield-demo.obiba.org works again.